### PR TITLE
Feature: Node Authentication

### DIFF
--- a/socialdistribution/api/authentication.py
+++ b/socialdistribution/api/authentication.py
@@ -1,0 +1,20 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import authentication
+from rest_framework import exceptions
+
+from bettersocial.models import Node
+
+
+class NodeAuthentication(authentication.BasicAuthentication):
+    """A subclass of BasicAuth that allows HTTP Basic Authorization credentials to be checked against the list of `Node`s, instead of `User`s."""
+
+    def authenticate_credentials(self, userid, password, request = None):
+
+        node = Node.objects.filter(auth_username = userid, auth_password = password).first()
+
+        if node is None:
+            raise exceptions.AuthenticationFailed(_('Invalid username/password.'))
+
+        # I know we should really be returning a more complete User-like object here, but since this is used only really for DRF, it doesn't really matter. This middleware will not be active for the regular app.
+        # A benefit of this approach (albeit a less than ideal one) is that any view can test the type of `request.user` to see if a node or regular user has logged in, enabling different behaviour for each type.
+        return node, None

--- a/socialdistribution/api/urls.py
+++ b/socialdistribution/api/urls.py
@@ -7,8 +7,9 @@ app_name = 'api'
 
 router = routers.DefaultRouter()
 router.register(r'authors', views.AuthorViewSet)
+router.register(r'author', views.AuthorViewSet)
 
-author_router = routers.NestedSimpleRouter(router, r'authors', lookup = 'author')
+author_router = routers.NestedSimpleRouter(router, r'author', lookup = 'author')
 author_router.register(r'posts', views.PostViewSet)
 
 post_router = routers.NestedSimpleRouter(author_router, r'posts', lookup = 'post')

--- a/socialdistribution/api/views.py
+++ b/socialdistribution/api/views.py
@@ -25,7 +25,7 @@ class AuthorViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.L
 
         new_response = OrderedDict()
 
-        new_response['type'] = 'followers'
+        new_response['type'] = 'authors'
         new_response['items'] = response.data
 
         response.data = new_response

--- a/socialdistribution/api/views.py
+++ b/socialdistribution/api/views.py
@@ -15,14 +15,10 @@ class PostViewSet(viewsets.ModelViewSet):
 
         return super().retrieve(request, *args, **kwargs)
 
-    # permission_classes = [permissions.IsAuthenticated]
-
 
 class AuthorViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin, mixins.UpdateModelMixin):
     queryset = models.Author.objects.all()
     serializer_class = serializers.AuthorSerializer
-
-    # permission_classes = [permissions.IsAuthenticated]
 
     def list(self, request, *args, **kwargs):
         response = super().list(request, *args, **kwargs)
@@ -40,16 +36,13 @@ class AuthorViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.L
 class CommentViewSet(viewsets.ModelViewSet):
     queryset = models.Comment.objects.all()
     serializer_class = serializers.CommentSerializer
-    # permission_classes = [permissions.IsAuthenticated]
 
 
 class CommentLikeViewSet(viewsets.ModelViewSet):
     queryset = models.Like.objects.all()
     serializer_class = serializers.CommentLikeSerializer
-    # permission_classes = [permissions.IsAuthenticated]
 
 
 class PostLikeViewSet(viewsets.ModelViewSet):
     queryset = models.Like.objects.all()
     serializer_class = serializers.PostLikeSerializer
-    # permission_classes = [permissions.IsAuthenticated]

--- a/socialdistribution/bettersocial/models.py
+++ b/socialdistribution/bettersocial/models.py
@@ -1,6 +1,7 @@
 import uuid as uuid
 from uuid import UUID
 
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType as DjangoContentType
@@ -303,8 +304,12 @@ class Inbox(models.Model):
 # -- Utility -- #
 
 
-class Node(models.Model):
-    """A bidirectional connection between this server and another."""
+class Node(AbstractBaseUser):
+    """A bidirectional connection between this server and another. Subclasses AbstractBaseUser since we kind of use it as a user object."""
+
+    # Unsets fields from AbstractBaseUser
+    password = None
+    last_login = None
 
     host = models.CharField(max_length = 255, unique = True)
 
@@ -322,6 +327,38 @@ class Node(models.Model):
     class Meta:
         verbose_name = 'Node'
         verbose_name_plural = 'Nodes'
+
+    def get_username(self):
+        return self.host
+
+    def clean(self):
+        pass
+
+    def set_password(self, raw_password):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    def check_password(self, raw_password):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    def set_unusable_password(self):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    def has_usable_password(self):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    def _legacy_get_session_auth_hash(self):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    def get_session_auth_hash(self):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    @classmethod
+    def get_email_field_name(cls):
+        raise NotImplementedError('This method is not implemented for the Node model!')
+
+    @classmethod
+    def normalize_username(cls, username):
+        raise NotImplementedError('This method is not implemented for the Node model!')
 
 
 class UUIDRemoteCache(models.Model):

--- a/socialdistribution/socialdistribution/settings.py
+++ b/socialdistribution/socialdistribution/settings.py
@@ -84,10 +84,12 @@ WSGI_APPLICATION = 'socialdistribution.wsgi.application'
 # Rest Framework
 
 REST_FRAMEWORK = {
-    # Use Django's standard `django.contrib.auth` permissions,
-    # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        # 'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        'rest_framework.permissions.IsAuthenticated'
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'api.authentication.NodeAuthentication',
     ]
 }
 


### PR DESCRIPTION
#### Summary
- Add custom Basic Auth class that allows to authenticate using a node username and password
  - Regular Session Auth is still permitted, allowing regular users to use the API without any extra work
- All endpoints now require one of two authentication to be present, unless specified otherwise
  -  We will have to protect some of the "internal-use" endpoints later on
- Includes a fix for the stupid `/authors/{uuid}` vs `/author/{uuid}` thing

#### Important Note
- Because of the way I've implemented Basic Auth, I needed to make `Node` at least inherit from `AbstractBaseUser`. This is why I had to stub out all the unused methods